### PR TITLE
Popravek za skladanje s pravili FS + SI enote

### DIFF
--- a/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko.tex
+++ b/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko.tex
@@ -70,6 +70,7 @@
 \checkoddpage
 \ifoddpage
 \else
+\thispagestyle{fancy_nohead}
 \mbox{}
 \newpage
 \fi}

--- a/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/teorija/teoreticneOsnove.tex
+++ b/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/teorija/teoreticneOsnove.tex
@@ -317,6 +317,15 @@ elementov v enačbah upoštevajte »Priporočila avtorjem študijskih in strokov
 publikacij na Fakulteti za strojništvo v Ljubljani« avtorja 
 viš.~pred.~dr.~Stropnika \cite{stropnik_1997}.
 
+\section{Enote}\label{sec:enote}
+
+V besedilu se velikokrat pojavi potreba po omembi fizikalnih veličin z njihovimi pripadajočimi SI enotami.  
+Enote se pišejo s pokončnim tekstom in so od veličine oddaljene z enim nedeljivim presledkom.
+
+Primer uporabe: Temperatura znaša 273,15~K.
+
+\LaTeX, v primeru uporabe standardnega presledka, na koncu vrstic zlomi veličino in enoto, tako da se veličina nahaja na koncu prejšnje vrstice, enota pa v novi vrstici. Temu se izognemu tako, da uporabimo nedeljivi presledek. Ta je v \LaTeX u dosegljiv z znakom tilda \textbf{\~}.
+
 \section{Citiranje in navajanje virov}\label{sec:citiranje}
 
 Pri navajanju virov uporabljajte slovensko inačico IEEE standarda. Citiranje 


### PR DESCRIPTION
Dodana 73 vrstica, za sledenje smernicam FS UL. Vrstica odstrani glave na praznih vstavljenih straneh pred glavnimi poglavji. S tem se pdf dokumenti skladajo s smernicami FS UL in ne bo več prihajalo do popravkov s strani komisije. Izvor spremembe so lastne izkušnje podprte z veliko večino sovrstnikov.

Dodano je tudi kratko poglavje o enotah, ki poda dobro prakso uporabe nedeljivih presledkov. Velika večina vrstnikov je s tem imelo težave.