### PR TITLE
fix: dodaj \phantomsection za pravilne hyperlinke v kazalu

### DIFF
--- a/Doktorska naloga/oznake/oznake.tex
+++ b/Doktorska naloga/oznake/oznake.tex
@@ -3,12 +3,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \Large\textbf{Seznam uporabljenih simbolov}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \begin{longtable}[l]{@{}p{.15\textwidth}@{}p{.15\textwidth}@{}p{.7\textwidth}@{}}
 \hline
 Oznaka & Enota & Pomen\\
@@ -52,12 +52,12 @@ z & začetni\\
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 \Large\textbf{Seznam uporabljenih okrajšav}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 
 \begin{longtable}[l]{@{}p{.2\textwidth}@{}p{.8\textwidth}@{}}
 \hline

--- a/Doktorska naloga/prveStrani/kazala.tex
+++ b/Doktorska naloga/prveStrani/kazala.tex
@@ -14,11 +14,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo slik}
 \Large\textbf{Kazalo slik}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo slik}
 % Seznam slik
 \makeatletter
 \renewcommand{\listoffigures}{\@starttoc{lof}}
@@ -39,11 +40,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo preglednic}
 \Large\textbf{Kazalo preglednic}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo preglednic}
 % Seznam tabel
 \makeatletter
 \renewcommand{\listoftables}{\@starttoc{lot}}

--- a/English template for VSS I.st and MAG II.st. - two-sided/abbreviations/abbreviations.tex
+++ b/English template for VSS I.st and MAG II.st. - two-sided/abbreviations/abbreviations.tex
@@ -2,12 +2,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{List of used symbols}
 \Large\textbf{List of used symbols}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{List of used symbols}
 \begin{longtable}[l]{@{}p{.15\textwidth}@{}p{.15\textwidth}@{}p{.7\textwidth}@{}}
 \hline
 Symbol & Unit & Meaning\\
@@ -51,12 +51,12 @@ z & začetni\\
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{List of used acronyms}
 \Large\textbf{List of used acronyms}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{List of used acronyms}
 
 \begin{longtable}[l]{@{}p{.2\textwidth}@{}p{.8\textwidth}@{}}
 \hline

--- a/English template for VSS I.st and MAG II.st. - two-sided/firstPages/tocs.tex
+++ b/English template for VSS I.st and MAG II.st. - two-sided/firstPages/tocs.tex
@@ -14,11 +14,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{List of figures}
 \Large\textbf{List of figures}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{List of figures}
 
 % Seznam slik
 \makeatletter
@@ -40,11 +41,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{List of tables}
 \Large\textbf{List of tables}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{List of tables}
 % Seznam tabel
 \makeatletter
 \renewcommand{\listoftables}{\@starttoc{lot}}

--- a/Predloga za UN I.st. RRP - enostransko/oznake/oznake.tex
+++ b/Predloga za UN I.st. RRP - enostransko/oznake/oznake.tex
@@ -1,12 +1,12 @@
 % !TeX spellcheck = si_SI
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \Large\textbf{Seznam uporabljenih simbolov}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \begin{longtable}[l]{@{}p{.15\textwidth}@{}p{.15\textwidth}@{}p{.7\textwidth}@{}}
 \hline
 Oznaka & Enota & Pomen\\
@@ -50,12 +50,12 @@ z & začetni\\
 
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 \Large\textbf{Seznam uporabljenih okrajšav}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 
 \begin{longtable}[l]{@{}p{.2\textwidth}@{}p{.8\textwidth}@{}}
 \hline

--- a/Predloga za UN I.st. RRP - enostransko/prveStrani/kazala.tex
+++ b/Predloga za UN I.st. RRP - enostransko/prveStrani/kazala.tex
@@ -12,11 +12,12 @@
 \newpage
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo slik}
 \Large\textbf{Kazalo slik}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo slik}
 % Seznam slik
 \makeatletter
 \renewcommand{\listoffigures}{\@starttoc{lof}}
@@ -36,11 +37,12 @@
 \newpage
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo preglednic}
 \Large\textbf{Kazalo preglednic}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo preglednic}
 % Seznam tabel
 \makeatletter
 \renewcommand{\listoftables}{\@starttoc{lot}}

--- a/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/oznake/oznake.tex
+++ b/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/oznake/oznake.tex
@@ -2,12 +2,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \Large\textbf{Seznam uporabljenih simbolov}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih simbolov}
 \begin{longtable}[l]{@{}p{.15\textwidth}@{}p{.15\textwidth}@{}p{.7\textwidth}@{}}
 \hline
 Oznaka & Enota & Pomen\\
@@ -51,12 +51,12 @@ z & začetni\\
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 \Large\textbf{Seznam uporabljenih okrajšav}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-
-\addcontentsline{toc}{section}{Seznam uporabljenih okrajšav}
 
 \begin{longtable}[l]{@{}p{.2\textwidth}@{}p{.8\textwidth}@{}}
 \hline

--- a/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/prveStrani/kazala.tex
+++ b/Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/prveStrani/kazala.tex
@@ -14,11 +14,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo slik}
 \Large\textbf{Kazalo slik}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo slik}
 
 % Seznam slik
 \makeatletter
@@ -40,11 +41,12 @@
 \addifeven
 
 \vspace*{0mm}
+\phantomsection
+\addcontentsline{toc}{section}{Kazalo preglednic}
 \Large\textbf{Kazalo preglednic}\normalsize
 \vskip\medskipamount
 \leaders\vrule width \textwidth\vskip0.4pt
 \vskip\bigskipamount
-\addcontentsline{toc}{section}{Kazalo preglednic}
 % Seznam tabel
 \makeatletter
 \renewcommand{\listoftables}{\@starttoc{lot}}


### PR DESCRIPTION
## Povzetek
  - Dodana `\phantomsection` pred vsak `\addcontentsline` pri ročno oblikovanih naslovih (kazalo slik, kazalo
  preglednic, seznam simbolov, seznam okrajšav) v vseh 4 predlogah
  - Prej je klik na vnos v kazalu preusmeril bralca napačno na prvo stran, ker `\addcontentsline` brez `\phantomsection` ne
  ustvari pravilnega ankra za hyperref

  ## Spremenjene datoteke
  - `Doktorska naloga/prveStrani/kazala.tex`
  - `Doktorska naloga/oznake/oznake.tex`
  - `English template for VSS I.st and MAG II.st. - two-sided/firstPages/tocs.tex`
  - `English template for VSS I.st and MAG II.st. - two-sided/abbreviations/abbreviations.tex`
  - `Predloga za UN I.st. RRP - enostransko/prveStrani/kazala.tex`
  - `Predloga za UN I.st. RRP - enostransko/oznake/oznake.tex`
  - `Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/prveStrani/kazala.tex`
  - `Predloga za VSS I.st. PAP in MAG II.st. - dvostransko/oznake/oznake.tex`